### PR TITLE
Force using HTTP/1.1 since PayPal changed it's API

### DIFF
--- a/modules/v6c_merchantlink/v6c_mlpaymentgateway.php
+++ b/modules/v6c_merchantlink/v6c_mlpaymentgateway.php
@@ -742,6 +742,7 @@ class v6c_mlPaymentGateway extends v6c_mlPaymentGateway_parent
 	        @curl_setopt($hCurl, CURLOPT_SSL_VERIFYPEER, false);
 	        @curl_setopt($hCurl, CURLOPT_SSL_VERIFYHOST, false);
 	        @curl_setopt($hCurl, CURLOPT_VERBOSE, true);
+	        @curl_setopt($hCurl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 	        $bResult = @curl_exec($hCurl);
 	        if (!$bResult)
 	        {


### PR DESCRIPTION
> In a bulletin dated October 18, 2011, we announced that we were going to expand the number of IP addresses for http://www.paypal.com to improve our site’s performance, scalability and availability. As part of this transition, we planned to discontinue support for HTTP 1.0 protocol starting October 7, 2013.
> 
> We have recently identified that this change may impact the ability of some of our merchants to perform IPN (Instant Payment Notification) post-back validation or PDT (Payment Data Transfer) posts to http://www.paypal.com and ipnpb.paypal.com. This happens when the IPN or PDT scripts use HTTP 1.0 protocol and do not include the “Host: http://www.paypal.com” or “Host: ipnpb.paypal.com” header in the HTTP request.
